### PR TITLE
Minor lexicase improvement

### DIFF
--- a/test/erp12/ga_clj/toolbox_test.cljc
+++ b/test/erp12/ga_clj/toolbox_test.cljc
@@ -79,7 +79,12 @@
       (is (= :B (:name (tb/lexicase-selection {:candidates population :cases '(0 3 2 4 1) :errors-fn :errors}))))
       (is (= :A (:name (tb/lexicase-selection {:candidates population :cases '(1 0 3 2 4) :errors-fn :errors}))))
       (is (= :C (:name (tb/lexicase-selection {:candidates population :cases '(2 4 3 0 1) :errors-fn :errors}))))
-      (is (= :E (:name (tb/lexicase-selection {:candidates population :cases '(2 0 3 4 1) :errors-fn :errors})))))))
+      (is (= :E (:name (tb/lexicase-selection {:candidates population :cases '(2 0 3 4 1) :errors-fn :errors})))))
+    (testing "Epsilon lexicase selection"
+      (is (= :B (:name (tb/lexicase-selection {:candidates population
+                                               :cases '(4 1 0 3 2)
+                                               :errors-fn :errors
+                                               :epsilon [1 1 1 1 6]})))))))
 
 (deftest uniform-addition-test
   (let [mutate (tb/make-uniform-addition {:addition-rate  0.5


### PR DESCRIPTION
Removes expensive logic to count the min size of all error vectors. If user doesn't supply the size of the error vectors explicitly, it is assumed that the size of any one error vector is correct.

In very rare cases when error vectors may have variable length, the user _must_ specify the number of errors to use. for each selection event.